### PR TITLE
Support physical keyboard inputs

### DIFF
--- a/addons/input_prompts/resources/keyboard_textures.gd
+++ b/addons/input_prompts/resources/keyboard_textures.gd
@@ -25,7 +25,7 @@ func get_texture(event: InputEvent) -> Texture2D:
 	var key_event := event as InputEventKey
 	var scancode := key_event.keycode
 	if scancode == 0:
-		scancode = key_event.physical_keycode;
+		scancode = key_event.physical_keycode
 	return textures[OS.get_keycode_string(scancode)]
 
 

--- a/addons/input_prompts/resources/keyboard_textures.gd
+++ b/addons/input_prompts/resources/keyboard_textures.gd
@@ -24,6 +24,8 @@ func get_texture(event: InputEvent) -> Texture2D:
 		return null
 	var key_event := event as InputEventKey
 	var scancode := key_event.keycode
+	if scancode == 0:
+		scancode = key_event.physical_keycode;
 	return textures[OS.get_keycode_string(scancode)]
 
 


### PR DESCRIPTION
Godot switched keyboard inputs to use a different key on the InputEventKey

https://docs.godotengine.org/en/stable/classes/class_inputeventkey.html#class-inputeventkey-property-physical-keycode