### PR TITLE
fix: add some deadzone for joypad motion detection

### DIFF
--- a/addons/input_prompts/input_prompt_manager.gd
+++ b/addons/input_prompts/input_prompt_manager.gd
@@ -46,7 +46,9 @@ var preferred_icons := InputPrompt.Icons.AUTOMATIC:
 
 ## The deadzone value used to detect joypad activity. The default value is determined by the
 ## "addons/input_prompts/joypad_detection_deadzone" setting in [ProjectSettings].
-var joypad_detection_deadzone := ProjectSettings.get_setting("addons/input_prompts/joypad_detection_deadzone", 0.5)
+var joypad_detection_deadzone := ProjectSettings.get_setting(
+	"addons/input_prompts/joypad_detection_deadzone", 0.5
+)
 
 
 ## Force all [InputPrompt] nodes to refresh their icons and events.

--- a/addons/input_prompts/input_prompt_manager.gd
+++ b/addons/input_prompts/input_prompt_manager.gd
@@ -44,6 +44,10 @@ var preferred_icons := InputPrompt.Icons.AUTOMATIC:
 			icons = value
 		emit_signal("icons_changed")
 
+## The deadzone value used to detect joypad activity. The default value is determined by the
+## "addons/input_prompts/joypad_detection_deadzone" setting in [ProjectSettings].
+var joypad_detection_deadzone := ProjectSettings.get_setting("addons/input_prompts/joypad_detection_deadzone", 0.5)
+
 
 ## Force all [InputPrompt] nodes to refresh their icons and events.
 ## Must be called if the [InputMap] is changed.
@@ -106,8 +110,10 @@ func _input(event: InputEvent):
 			icons = InputPrompt.Icons.KEYBOARD
 			emit_signal("icons_changed")
 	if event is InputEventJoypadButton or event is InputEventJoypadMotion:
-		if event is InputEventJoypadMotion and event.axis_value < 0.05:
+		# Do not detect Joypad unless value exceeds deadzone
+		if event is InputEventJoypadMotion and absf(event.axis_value) < joypad_detection_deadzone:
 			return
+
 		var device = event.device
 		var joy_name = Input.get_joy_name(device)
 		if joy_name.find("Xbox"):

--- a/addons/input_prompts/input_prompt_manager.gd
+++ b/addons/input_prompts/input_prompt_manager.gd
@@ -106,6 +106,8 @@ func _input(event: InputEvent):
 			icons = InputPrompt.Icons.KEYBOARD
 			emit_signal("icons_changed")
 	if event is InputEventJoypadButton or event is InputEventJoypadMotion:
+		if event is InputEventJoypadMotion and event.axis_value < 0.05:
+			return
 		var device = event.device
 		var joy_name = Input.get_joy_name(device)
 		if joy_name.find("Xbox"):

--- a/addons/input_prompts/plugin.gd
+++ b/addons/input_prompts/plugin.gd
@@ -15,6 +15,7 @@ func _enter_tree():
 		if not ProjectSettings.has_setting(deadzone_setting):
 			ProjectSettings.set_setting(deadzone_setting, 0.5)
 			ProjectSettings.set_initial_value(deadzone_setting, 0.5)
+			ProjectSettings.set_as_basic(deadzone_setting, true)
 			var property_info = {
 				"name": deadzone_setting,
 				"type": TYPE_FLOAT,

--- a/addons/input_prompts/plugin.gd
+++ b/addons/input_prompts/plugin.gd
@@ -10,6 +10,19 @@ func _enter_tree():
 	add_autoload_singleton("PromptManager", "res://addons/input_prompts/input_prompt_manager.gd")
 	add_inspector_plugin(inspector_plugin)
 
+	if Engine.is_editor_hint():
+		var deadzone_setting := "addons/input_prompts/joypad_detection_deadzone"
+		if not ProjectSettings.has_setting(deadzone_setting):
+			ProjectSettings.set_setting(deadzone_setting, 0.5)
+			ProjectSettings.set_initial_value(deadzone_setting, 0.5)
+			var property_info = {
+				"name": deadzone_setting,
+				"type": TYPE_FLOAT,
+				"hint": PROPERTY_HINT_RANGE,
+				"hint_string": "0,1"
+			}
+		ProjectSettings.save()
+
 
 func _exit_tree():
 	remove_inspector_plugin(inspector_plugin)


### PR DESCRIPTION
Prior to this change, if there was both a keyboard and joypad connected and the user was using the keyboard, but there was some stick drift with the joypad, input detection would bounce between keyboard and joypad.

This change adds a minimum axis_value that a InputEventJoypadMotion must have before detecting the input type as a joypad.

Ideally, it seems like this deadzone should be configurable, but I'm new to Godot and its plugin architecture and couldn't quite figure out how best to surface that as customizable.