### PR TITLE
Replace console errors with configuration warnings

### DIFF
--- a/addons/input_prompts/action_prompt/action_prompt.gd
+++ b/addons/input_prompts/action_prompt/action_prompt.gd
@@ -44,6 +44,8 @@ func _set_action(new_action: String):
 		events.append(ev)
 	_update_icon()
 
+	update_configuration_warnings()
+
 
 func _set_icon(new_icon):
 	icon = new_icon
@@ -69,8 +71,6 @@ func _update_icon():
 	if display_icon == Icons.KEYBOARD:
 		var types = [InputEventKey, InputEventMouseButton]
 		var ev = _find_event(events, types)
-		if not (ev is InputEventKey or ev is InputEventMouseButton):
-			push_error("No Key/Mouse input for " + action + " in InputMap")
 		if ev is InputEventKey:
 			var textures := PromptManager.get_keyboard_textures()
 			texture = textures.get_texture(ev)
@@ -80,8 +80,6 @@ func _update_icon():
 	else:
 		var types = [InputEventJoypadButton, InputEventJoypadMotion]
 		var ev = _find_event(events, types)
-		if not (ev is InputEventJoypadButton or ev is InputEventJoypadMotion):
-			push_error("No Joypad input for " + action + " in InputMap")
 		if ev is InputEventJoypadButton:
 			var textures := PromptManager.get_joypad_button_textures(display_icon)
 			texture = textures.get_texture(ev)
@@ -127,3 +125,23 @@ func _get_property_list():
 		}
 	)
 	return properties
+
+
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings: PackedStringArray = []
+
+	# Check that the action is associated with Keyboard/Mouse in the InputMap
+	if icon == Icons.AUTOMATIC or icon == Icons.KEYBOARD:
+		var types = [InputEventKey, InputEventMouseButton]
+		var ev = _find_event(events, types)
+		if not (ev is InputEventKey or ev is InputEventMouseButton):
+			warnings.append("No Key/Mouse input for " + action + " in InputMap.")
+
+	# Check that the action is associated with Joypad in the InputMap
+	if icon == Icons.AUTOMATIC or icon != Icons.KEYBOARD:
+		var types = [InputEventJoypadButton, InputEventJoypadMotion]
+		var ev = _find_event(events, types)
+		if not (ev is InputEventJoypadButton or ev is InputEventJoypadMotion):
+			warnings.append("No Joypad input for " + action + " in InputMap.")
+
+	return warnings

--- a/addons/input_prompts/action_prompt/action_prompt.gd
+++ b/addons/input_prompts/action_prompt/action_prompt.gd
@@ -25,12 +25,23 @@ var icon: int = Icons.AUTOMATIC:
 
 
 func _ready():
+	ProjectSettings.settings_changed.connect(_update_events)
+	_update_events()
 	_update_icon()
 
 
 func _set_action(new_action: String):
 	action = new_action
+	_update_events()
+	_update_icon()
 
+
+func _set_icon(new_icon):
+	icon = new_icon
+	_update_icon()
+
+
+func _update_events():
 	# In the Editor, InputMap reflects Editor settings
 	# Read the list of actions from ProjectSettings instead
 	# TODO: Find a cleaner way to cast these values
@@ -42,14 +53,7 @@ func _set_action(new_action: String):
 	events = []
 	for ev in tmp:
 		events.append(ev)
-	_update_icon()
-
 	update_configuration_warnings()
-
-
-func _set_icon(new_icon):
-	icon = new_icon
-	_update_icon()
 
 
 func _find_event(list: Array, types: Array):


### PR DESCRIPTION
Instead of pushing an error to the console every time that an input cannot be found in the InputMap, we can add it to the ActionPrompt's configuration warnings instead.

This reduces the amount of console output and makes it clearer where the issue lies.

Closes #6.

---

@betalars, could you please test this and let me know if you agree that it addresses the issue you raised in #6?