### PR TITLE
Add function to refresh input prompts

### DIFF
--- a/addons/input_prompts/action_prompt/action_prompt.gd
+++ b/addons/input_prompts/action_prompt/action_prompt.gd
@@ -93,6 +93,11 @@ func _update_icon():
 	queue_redraw()
 
 
+func _refresh():
+	_update_events()
+	_update_icon()
+
+
 func _input(event: InputEvent):
 	if not event.is_action_pressed(action):
 		return

--- a/addons/input_prompts/input_prompt.gd
+++ b/addons/input_prompts/input_prompt.gd
@@ -32,6 +32,10 @@ func _update_icon():
 	pass
 
 
+func _refresh():
+	_update_icon()
+
+
 func _input(event: InputEvent):
 	if not events.any(func(e): return event.is_match(e)):
 		return
@@ -44,7 +48,17 @@ func _input(event: InputEvent):
 
 func _enter_tree():
 	PromptManager.icons_changed.connect(_update_icon)
+	add_to_group("_input_prompts")
 
 
 func _exit_tree():
+	remove_from_group("_input_prompts")
 	PromptManager.icons_changed.disconnect(_update_icon)
+
+
+## Force this [InputPrompt] node to refresh its icons and events.
+## Must be called if the [InputMap] is changed.
+## [br][br]
+## [b]Note[/b]: Use [InputPromptManager] to refresh all nodes at once.
+func refresh():
+	_refresh()

--- a/addons/input_prompts/input_prompt_manager.gd
+++ b/addons/input_prompts/input_prompt_manager.gd
@@ -45,6 +45,14 @@ var preferred_icons := InputPrompt.Icons.AUTOMATIC:
 		emit_signal("icons_changed")
 
 
+## Force all [InputPrompt] nodes to refresh their icons and events.
+## Must be called if the [InputMap] is changed.
+func refresh() -> void:
+	var prompts := get_tree().get_nodes_in_group("_input_prompts")
+	for prompt in prompts:
+		prompt.call_deferred("refresh")
+
+
 ## Return the [KeyboardTextures] used by [KeyPrompt] nodes.
 func get_keyboard_textures() -> KeyboardTextures:
 	return preload("res://addons/input_prompts/key_prompt/keys.tres")


### PR DESCRIPTION
Calling the refresh() function of a specific prompt node forces it to update its events and icons. Calling the refresh() function of the PromptManager singleton refreshes all input prompts.

refresh() must be called whenever the events associated with an action in the InputMap changes, because Godot does not provide an ability to detect changes in the InputMap.

Closes #8.

---

@SpyrexDE: Could you please give this a try and let me know if it does indeed fix the issue?  You should just be able to call `PromptManager.refresh()`