### PR TITLE
fix: joy_name indexes correctly referenced

### DIFF
--- a/addons/input_prompts/input_prompt_manager.gd
+++ b/addons/input_prompts/input_prompt_manager.gd
@@ -166,11 +166,11 @@ func _input(event: InputEvent):
 
 		var device = event.device
 		var joy_name = Input.get_joy_name(device)
-		if joy_name.find("Xbox"):
+		if joy_name.find("Xbox") != -1:
 			joy_icons = InputPrompt.Icons.XBOX
-		elif joy_name.find("DualShock") or joy_name.find("PS"):
+		elif joy_name.find("DualShock") != -1 or joy_name.find("PS") != -1:
 			joy_icons = InputPrompt.Icons.SONY
-		elif joy_name.find("Nintendo"):
+		elif joy_name.find("Nintendo") != -1:
 			joy_icons = InputPrompt.Icons.NINTENDO
 		else:
 			joy_icons = InputPrompt.Icons.XBOX


### PR DESCRIPTION
# Fixes the automatic detection of controllers

`find` returns the index of where the string was found in the word. Controllers were always defaulting to XBox if the match was at index 0. An example is the `PS4 Controller` it was matching at index 0 on the `joy_name.find("PS")` criteria, so it was being classed as falsy and then falling through to the `else`.

# Example

PS4 Controller before fix:

![image](https://github.com/Pennycook/godot-input-prompts/assets/397126/216c5321-bb9f-4743-9a54-05c333013040)

PS4 Controller after fix:

<img width="109" alt="image" src="https://github.com/Pennycook/godot-input-prompts/assets/397126/1355ff1d-99c0-422f-a7ee-bcfa42e31f05">
