### PR TITLE
Fix project using incompatible Godot version

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="godot-input-prompts"
 run/main_scene="res://demo/demo.tscn"
-config/features=PackedStringArray("4.1", "GL Compatibility")
+config/features=PackedStringArray("4.2", "GL Compatibility")
 config/icon="res://addons/input_prompts/icon.svg"
 
 [autoload]


### PR DESCRIPTION
ActionPrompt connects to the signal ProjectSettings.settings_changed, which was added in Godot 4.2. Opening the project in Godot 4.1 results in `res://addons/input_prompts/action_prompt/action_prompt.gd:28 - Parse Error: Cannot find member "settings_changed" in base "ProjectSettings".`