### PR TITLE
Convert physical keycodes to match active layout

### DIFF
--- a/addons/input_prompts/resources/keyboard_textures.gd
+++ b/addons/input_prompts/resources/keyboard_textures.gd
@@ -25,7 +25,9 @@ func get_texture(event: InputEvent) -> Texture2D:
 	var key_event := event as InputEventKey
 	var scancode := key_event.keycode
 	if scancode == 0:
-		scancode = key_event.physical_keycode
+		scancode = DisplayServer.keyboard_get_keycode_from_physical(
+			key_event.physical_keycode
+		)
 	return textures[OS.get_keycode_string(scancode)]
 
 


### PR DESCRIPTION
Show physical key prompts that match the player's active keyboard layout (instead of only QWERTY). For example, if a layout has DASH in place of WASD then physical WASD prompts convert to DASH.

Closes #16